### PR TITLE
Parameterizing logger

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,7 @@ default['nsq']['reload_services'] = false
 
 # Release URL. Defaults to bitly upstream
 default['nsq']['release_url'] = 'https://s3.amazonaws.com/bitly-downloads/nsq'
+
+# What logger binary to use for shipping logs. This needs to act like
+# logger(1) and at least support a -t parameter for tags.
+default['nsq']['logger_bin'] = 'logger'

--- a/templates/default/upstart.nsqadmin.conf.erb
+++ b/templates/default/upstart.nsqadmin.conf.erb
@@ -10,7 +10,7 @@ respawn
 script
   set -e
   mkfifo /tmp/nsqadmin-log-fifo
-  ( logger -t nsqadmin </tmp/nsqadmin-log-fifo & )
+  ( <%= node['nsq']['logger_bin'] %> -t nsqadmin </tmp/nsqadmin-log-fifo & )
   exec >/tmp/nsqadmin-log-fifo
   rm /tmp/nsqadmin-log-fifo
 

--- a/templates/default/upstart.nsqd.conf.erb
+++ b/templates/default/upstart.nsqd.conf.erb
@@ -17,7 +17,7 @@ respawn
 script
   set -e
   mkfifo /tmp/nsqd-log-fifo
-  ( logger -t nsqd </tmp/nsqd-log-fifo & )
+  ( <%= node['nsq']['logger_bin'] %> -t nsqd </tmp/nsqd-log-fifo & )
   exec >/tmp/nsqd-log-fifo
   rm /tmp/nsqd-log-fifo
 

--- a/templates/default/upstart.nsqlookupd.conf.erb
+++ b/templates/default/upstart.nsqlookupd.conf.erb
@@ -10,7 +10,7 @@ respawn
 script
   set -e
   mkfifo /tmp/nsqlookupd-log-fifo
-  ( logger -t nsqlookupd </tmp/nsqlookupd-log-fifo & )
+  ( <%= node['nsq']['logger_bin'] %> -t nsqlookupd </tmp/nsqlookupd-log-fifo & )
   exec >/tmp/nsqlookupd-log-fifo
   rm /tmp/nsqlookupd-log-fifo
 


### PR DESCRIPTION
As it says on the tin, set the `logger` binary used to be a tweakable parameter. 
