### PR TITLE
[WEBINF-1248] - Provide Ubuntu 18 support for nsqd role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .bundle
+.kitchen
+Berksfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,22 @@
+driver:
+  name: vagrant
+  customize:
+    memory: 2048
+    cpus: 2
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: true
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-18.04
+  - name: ubuntu-14.04
+
+suites:
+  - name: nsqd
+    run_list:
+      - recipe[nsq::nsqd]
+

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,5 @@
+source 'https://supermarket.chef.io'
+cookbook 'ark', '>=2.0.2' # not pinned to this version strongly, it just helps us escape dependency hell
+metadata
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 1.2.12 - Provide Ubuntu 18 support for nsqd role
 * 1.2.3 - Added support for missing nsqd options
 * 1.2.2 - Added support for customizing the system users used to run nsq services
 * 1.2.1 - Fixed bug in nsqlookupd upstart template when default attributes used

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Chef version 0.10.10+ and Ohai 0.6.12+ are required.
 
 ### Platform
 * Ubuntu 12.10
+* Ubuntu 18, _kinda_, support has been added to allow the `nsqd` role to work via systemd.
 
 **Notes**: This cookbook has been tested on the listed platforms only. It may work on other platforms with modification.
 

--- a/attributes/nsqd.rb
+++ b/attributes/nsqd.rb
@@ -115,9 +115,3 @@ default['nsq']['nsqd']['e2e_processing_latency_percentile'] = '1.0,0.99,0.95'
 
 # -e2e-processing-latency-window-time=10m0s: calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)
 default['nsq']['nsqd']['e2e_processing_latency_window_time'] = '10m0s'
-
-# controls where STDOUT for systemd scenarios outputs to
-default['nsq']['nsqd']['standard_output'] = 'file:/var/log/nsqd/output.log'
-
-# controls where STDERR for systemd scenarios outputs to
-default['nsq']['nsqd']['standard_error'] = 'file:/var/log/nsqd/error.log'

--- a/attributes/nsqd.rb
+++ b/attributes/nsqd.rb
@@ -115,3 +115,9 @@ default['nsq']['nsqd']['e2e_processing_latency_percentile'] = '1.0,0.99,0.95'
 
 # -e2e-processing-latency-window-time=10m0s: calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)
 default['nsq']['nsqd']['e2e_processing_latency_window_time'] = '10m0s'
+
+# controls where STDOUT for systemd scenarios outputs to
+default['nsq']['nsqd']['standard_output'] = 'file:/var/log/nsqd/output.log'
+
+# controls where STDERR for systemd scenarios outputs to
+default['nsq']['nsqd']['standard_error'] = 'file:/var/log/nsqd/error.log'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.11'
+version '1.2.12'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/recipes/nsqd.rb
+++ b/recipes/nsqd.rb
@@ -10,7 +10,10 @@
 
 include_recipe 'nsq'
 
-chef_gem 'semantic'
+chef_gem 'semantic' do
+  compile_time true
+end
+
 require 'semantic'
 
 nsq_release = "nsq-#{node['nsq']['version']}-#{node['nsq']['go_version']}"
@@ -25,24 +28,89 @@ directory node['nsq']['nsqd']['data_path'] do
 end
 
 if node['nsq']['setup_services']
-  template '/etc/init/nsqd.conf' do
-    action :create
-    source 'upstart.nsqd.conf.erb'
-    mode '0644'
-    # need to stop/start in order to reload config
-    if node['nsq']['reload_services']
-      notifies :stop, 'service[nsqd]', :immediately
-      notifies :start, 'service[nsqd]', :immediately
+
+  if node.platform?('ubuntu') && node['platform_version'].to_f >= 18.04
+
+    standard_error = node['nsq']['nsqd']['standard_error'].split('file:/')[1]
+    standard_output = node['nsq']['nsqd']['standard_output'].split('file:/')[1]
+
+    directory '/var/log/nsqd' do
+      action :create
+      mode '0770'
+      owner 'nsqd'
+      group 'nsqd'
+      recursive true
+    end
+
+    file standard_output do
+      action :create
+      mode '0770'
+      owner 'nsqd'
+      group 'nsqd'
+    end
+
+     file standard_error do
+      action :create
+      mode '0770'
+      owner 'nsqd'
+      group 'nsqd'
+    end
+
+
+    template '/srv/nsqd-start.sh' do
+      action :create
+      source 'nsqd-start.sh.erb'
+      mode '0550'
+      # mode '0777'
+      owner 'nsqd'
+      group 'nsqd'
+    end
+
+    template '/etc/systemd/system/nsqd.service' do
+      action :create
+      source 'systemd.nsqd.conf.erb'
+      mode '0644'
+      notifies :run, 'execute[systemctl-daemon-reload]'
+      # need to stop/start in order to reload config
+      if node['nsq']['reload_services']
+        notifies :stop, 'service[nsqd]', :immediately
+        notifies :start, 'service[nsqd]', :immediately
+      end
+    end
+
+    execute 'systemctl-daemon-reload' do
+      command 'systemctl daemon-reload'
+      action :nothing
+    end
+  else
+    template '/etc/init/nsqd.conf' do
+      action :create
+      source 'upstart.nsqd.conf.erb'
+      mode '0644'
+      # need to stop/start in order to reload config
+      if node['nsq']['reload_services']
+        notifies :stop, 'service[nsqd]', :immediately
+        notifies :start, 'service[nsqd]', :immediately
+      end
     end
   end
 
   service 'nsqd' do
-    provider Chef::Provider::Service::Upstart
-    action [:enable, :start]
-    supports stop: true, start: true, restart: true, status: true
-    # Conditionally subscribe to version updates
-    if node['nsq']['reload_services']
-      subscribes :restart, "ark[#{nsq_release}]", :delayed
+    if node.platform?('ubuntu') && node['platform_version'].to_f >= 18.04
+      provider Chef::Provider::Service::Systemd
+      action [:enable, :start]
+      supports stop: true, start: true, restart: true, status: true
+      if node['nsq']['reload_services']
+        subscribes :restart, "ark[#{nsq_release}]", :delayed
+      end
+    else
+      provider Chef::Provider::Service::Upstart
+      action [:enable, :start]
+      supports stop: true, start: true, restart: true, status: true
+      # Conditionally subscribe to version updates
+      if node['nsq']['reload_services']
+        subscribes :restart, "ark[#{nsq_release}]", :delayed
+      end
     end
   end
 end

--- a/recipes/nsqd.rb
+++ b/recipes/nsqd.rb
@@ -31,32 +31,6 @@ if node['nsq']['setup_services']
 
   if node.platform?('ubuntu') && node['platform_version'].to_f >= 18.04
 
-    standard_error = node['nsq']['nsqd']['standard_error'].split('file:/')[1]
-    standard_output = node['nsq']['nsqd']['standard_output'].split('file:/')[1]
-
-    directory '/var/log/nsqd' do
-      action :create
-      mode '0770'
-      owner 'nsqd'
-      group 'nsqd'
-      recursive true
-    end
-
-    file standard_output do
-      action :create
-      mode '0770'
-      owner 'nsqd'
-      group 'nsqd'
-    end
-
-     file standard_error do
-      action :create
-      mode '0770'
-      owner 'nsqd'
-      group 'nsqd'
-    end
-
-
     template '/srv/nsqd-start.sh' do
       action :create
       source 'nsqd-start.sh.erb'

--- a/templates/default/nsqd-start.sh.erb
+++ b/templates/default/nsqd-start.sh.erb
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -e
+mkfifo /tmp/nsqd-log-fifo
+( <%= node['nsq']['logger_bin'] %> -t nsqd </tmp/nsqd-log-fifo & )
+exec >/tmp/nsqd-log-fifo
+rm /tmp/nsqd-log-fifo
+
+/usr/local/bin/nsqd \
+       --data-path=<%= node['nsq']['nsqd']['data_path'] %> \
+      <%- if !node['nsq']['nsqd']['tls_required'] %>
+          --http-address=<%= node['nsq']['nsqd']['http_address'] %> \
+      <% end %>
+      <%- node['nsq']['nsqd']['lookupd_tcp_address'].each do |lookup_host| %>
+          --lookupd-tcp-address=<%= lookup_host %> \
+      <% end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.21') %>
+          --max-output-buffer-size=<%= node['nsq']['nsqd']['max_output_buffer_size'] %> \
+          --max-output-buffer-timeout=<%= node['nsq']['nsqd']['max_output_buffer_timeout'] %> \
+      <% end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.22') %>
+          --deflate=<%= node['nsq']['nsqd']['deflate'] %> \
+          --snappy=<%= node['nsq']['nsqd']['snappy'] %> \
+          --max-deflate-level=<%= node['nsq']['nsqd']['max_deflate_level'] %> \
+      <% end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.24') %>
+          --e2e-processing-latency-percentile=<%= node['nsq']['nsqd']['e2e_processing_latency_percentile'] %> \
+          --e2e-processing-latency-window-time=<%= node['nsq']['nsqd']['e2e_processing_latency_window_time'] %> \
+      <% end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) >= Semantic::Version.new('0.2.27') %>
+          --max-msg-size=<%= node['nsq']['nsqd']['max_msg_size'] %> \
+      <%- else %>
+          --max-message-size=<%= node['nsq']['nsqd']['max_message_size'] %> \
+      <%- end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.28') %>
+          --https-address=<%= node['nsq']['nsqd']['https_address'] %> \
+          <%- if !node['nsq']['nsqd']['tls_client_auth_policy'].empty? %>
+              --tls-client-auth-policy=<%= node['nsq']['nsqd']['tls_client_auth_policy'] %> \
+          <%- end %>
+          <%- if !node['nsq']['nsqd']['tls_root_ca_file'].empty? %>
+              --tls-root-ca-file=<%= node['nsq']['nsqd']['tls_root_ca_file'] %>
+          <%- end %>
+      <% end %>
+      <%- if Semantic::Version.new(node['nsq']['version']) >= Semantic::Version.new('0.2.29') %>
+          --max-req-timeout=<%= node['nsq']['nsqd']['max_req_timeout'] %> \
+          <%- if !node['nsq']['nsqd']['auth_http_address'].empty? %>
+              --auth-http-address=<%= node['nsq']['nsqd']['auth_http_address'] %> \
+          <%- end %>
+      <%- end %>
+      <%- if !node['nsq']['nsqd']['tls_key'].empty? %>
+         --tls-key=<%= node['nsq']['nsqd']['tls_key'] %> \
+      <%- end %>
+      <%- if !node['nsq']['nsqd']['tls_cert'].empty? %>
+         --tls-cert=<%= node['nsq']['nsqd']['tls_cert'] %> \
+      <%- end %>
+       --max-body-size=<%= node['nsq']['nsqd']['max_body_size'] %> \
+       --max-bytes-per-file=<%= node['nsq']['nsqd']['max_bytes_per_file'] %> \
+       --max-msg-timeout=<%= node['nsq']['nsqd']['max_msg_timeout'] %> \
+       --max-rdy-count=<%= node['nsq']['nsqd']['max_rdy_count'] %> \
+       --mem-queue-size=<%= node['nsq']['nsqd']['mem_queue_size'] %> \
+       --msg-timeout=<%= node['nsq']['nsqd']['msg_timeout'] %> \
+       --statsd-address=<%= node['nsq']['nsqd']['statsd_address'] %> \
+       --statsd-interval=<%= node['nsq']['nsqd']['statsd_interval'] %> \
+       --statsd-mem-stats=<%= node['nsq']['nsqd']['statsd_mem_stats'] %> \
+       --statsd-prefix=<%= node['nsq']['nsqd']['statsd_prefix'] %> \
+       --sync-every=<%= node['nsq']['nsqd']['sync_every'] %> \
+       --sync-timeout=<%= node['nsq']['nsqd']['sync_timeout'] %> \
+       --tcp-address=<%= node['nsq']['nsqd']['tcp_address'] %> \
+      <%- if !node['nsq']['nsqd']['broadcast_address'].empty? %>
+         --broadcast-address=<%= node['nsq']['nsqd']['broadcast_address'] %> \
+      <%- end %>
+       --verbose=<%= node['nsq']['nsqd']['verbose'] %> 2>&1
+

--- a/templates/default/systemd.nsqd.conf.erb
+++ b/templates/default/systemd.nsqd.conf.erb
@@ -1,0 +1,29 @@
+[Unit]
+Description=nsqd
+After=network.target
+StartLimitIntervalSec=30
+
+[Service]
+User=<%= node['nsq']['nsqd']['user'] %>
+Group=<%= node['nsq']['nsqd']['user'] %>
+<% if node['nsq']['nsqd']['filehandle_limit'] -%>
+LimitNOFILE=<%= node['nsq']['nsqd']['filehandle_limit'] %>
+<% end -%>
+<% if node['nsq']['nsqd']['nproc'] -%>
+LimitNPROC=<%= node['nsq']['nsqd']['nproc'] %>
+<% end -%>
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+ExecStart=/srv/nsqd-start.sh
+Restart=on-failure
+RestartSec=1
+<% if node['nsq']['nsqd']['standard_error'] -%>
+StandardError=<%= node['nsq']['nsqd']['standard_error'] %>
+<% end -%>
+<% if node['nsq']['nsqd']['standard_output'] -%>
+StandardOutput=<%= node['nsq']['nsqd']['standard_output'] %>
+<% end -%>
+StartLimitAction=none
+StartLimitBurst=5
+TimeoutStopSec=5
+
+<%# WorkingDirectory=/path/to/nsq/home %>

--- a/templates/default/systemd.nsqd.conf.erb
+++ b/templates/default/systemd.nsqd.conf.erb
@@ -16,14 +16,6 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 ExecStart=/srv/nsqd-start.sh
 Restart=on-failure
 RestartSec=1
-<% if node['nsq']['nsqd']['standard_error'] -%>
-StandardError=<%= node['nsq']['nsqd']['standard_error'] %>
-<% end -%>
-<% if node['nsq']['nsqd']['standard_output'] -%>
-StandardOutput=<%= node['nsq']['nsqd']['standard_output'] %>
-<% end -%>
 StartLimitAction=none
 StartLimitBurst=5
 TimeoutStopSec=5
-
-<%# WorkingDirectory=/path/to/nsq/home %>

--- a/test/integration/nsqd/default_test.rb
+++ b/test/integration/nsqd/default_test.rb
@@ -1,0 +1,9 @@
+describe service('nsqd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe http('http://127.0.0.1:4151/stats', enable_remote_worker: true) do
+  its('status') { should cmp 200 }
+end


### PR DESCRIPTION
* Work allows for app_fastcgi cookbook to converge properly on Ubuntu 18
* Provides a kitchen environment to view these changes

-------

## Question

The cookbook mostly* converges as-expected and I can see an nsqd service running. How can I test if it's actually working?

*I had some weirdness where I'd have to initially comment out [this line](https://github.com/sproutsocial/chef-nsq/blob/master/recipes/nsqd.rb#L14) and then uncomment it on a subsequent run to get it to run properly. It seems like it was choking on semantic not being there but from what I've read that seems to be the whole point of the `chef_gem` statement so maybe I just botched something there in terms of dependencies in the project.