### PR TITLE
[TRIAGE-1230] systemd service start on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 1.3.2 - nsqd, nsqlookupd start on boot for systemd
 * 1.3.1 - Add support for filehandle + process limits for nsqlookupd
 * 1.3.0 - Provide Ubuntu 18 support for nsqlookupd role
 * 1.2.12 - Provide Ubuntu 18 support for nsqd role

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.1'
+version '1.3.2'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/templates/default/systemd.nsqd.conf.erb
+++ b/templates/default/systemd.nsqd.conf.erb
@@ -19,3 +19,6 @@ RestartSec=1
 StartLimitAction=none
 StartLimitBurst=5
 TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/systemd.nsqlookupd.conf.erb
+++ b/templates/default/systemd.nsqlookupd.conf.erb
@@ -19,3 +19,6 @@ RestartSec=1
 StartLimitAction=none
 StartLimitBurst=5
 TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Currently `systemctl is-enabled nsqd` says `static` instead of `enabled`.
Hopefully this will enable it and make it start on boot.

How do I "release" a new version of this?