### PR TITLE
EFFECT-186 Update nsqadmin to work with Ubuntu 18.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 1.3.3 - Add systemd support for nsqadmin
 * 1.3.2 - nsqd, nsqlookupd start on boot for systemd
 * 1.3.1 - Add support for filehandle + process limits for nsqlookupd
 * 1.3.0 - Provide Ubuntu 18 support for nsqlookupd role

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.2'
+version '1.3.3'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/recipes/nsqadmin.rb
+++ b/recipes/nsqadmin.rb
@@ -13,19 +13,47 @@ include_recipe 'nsq'
 nsq_release = "nsq-#{node['nsq']['version']}-#{node['nsq']['go_version']}"
 
 if node['nsq']['setup_services']
-  template '/etc/init/nsqadmin.conf' do
-    action :create
-    source 'upstart.nsqadmin.conf.erb'
-    mode '0644'
-    # need to stop/start in order to reload config
-    if node['nsq']['reload_services']
-      notifies :stop, 'service[nsqadmin]', :immediately
-      notifies :start, 'service[nsqadmin]', :immediately
+
+  if node.platform?('ubuntu') && node['platform_version'].to_f >= 18.04
+
+    template '/etc/systemd/system/nsqadmin.service' do
+      action :create
+      source 'systemd.nsqadmin.conf.erb'
+      mode '0644'
+      notifies :run, 'systemd_unit[nsqadmin.service]', :delayed
+      # need to stop/start in order to reload config
+      if node['nsq']['reload_services']
+        notifies :stop, 'service[nsqadmin]', :immediately
+        notifies :start, 'service[nsqadmin]', :immediately
+      end
+    end
+
+    template "#{node['chef-nsq']['script_dir']}/nsqadmin-start.sh" do
+      action :create
+      source 'nsqadmin-start.sh.erb'
+      mode '0550'
+      owner node['nsq']['nsqadmin']['user']
+      group node['nsq']['nsqadmin']['user']
+    end
+
+    systemd_unit 'nsqadmin.service' do
+      action :nothing
+    end
+
+  else
+    template '/etc/init/nsqadmin.conf' do
+      action :create
+      source 'upstart.nsqadmin.conf.erb'
+      mode '0644'
+      # need to stop/start in order to reload config
+      if node['nsq']['reload_services']
+        notifies :stop, 'service[nsqadmin]', :immediately
+        notifies :start, 'service[nsqadmin]', :immediately
+      end
     end
   end
 
   service 'nsqadmin' do
-    provider Chef::Provider::Service::Upstart
     action [:enable, :start]
     supports stop: true, start: true, restart: true, status: true
     if node['nsq']['reload_services']

--- a/templates/default/nsqadmin-start.sh.erb
+++ b/templates/default/nsqadmin-start.sh.erb
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+mkfifo /tmp/nsqadmin-log-fifo
+( <%= node['nsq']['logger_bin'] %> -t nsqadmin </tmp/nsqadmin-log-fifo & )
+exec >/tmp/nsqadmin-log-fifo
+rm /tmp/nsqadmin-log-fifo
+
+exec su -s /bin/sh -c 'exec "$0" "$@"' <%= node["nsq"]["nsqadmin"]["user"] %> -- /usr/local/bin/nsqadmin \
+       --template-dir <%= node["nsq"]["nsqadmin"]["nsqd_template_dir"] %> \
+       <%- node["nsq"]["nsqadmin"]["lookupd_http_address"].each do |lookup_host| %>
+           --lookupd-http-address=<%= lookup_host %> \
+       <%- end %>
+       --use-statsd-prefixes=<%= node["nsq"]["nsqadmin"]["use_statsd_prefixes"] %> \
+       --statsd-interval=<%= node["nsq"]["nsqadmin"]["statsd_interval"] %> \
+       --proxy-graphite=<%= node["nsq"]["nsqadmin"]["proxy_graphite"] %> \
+       <% if node["nsq"]["nsqadmin"]["graphite_url"] != "" then %>
+       --graphite-url=<%= node["nsq"]["nsqadmin"]["graphite_url"] %> \
+       <% end %>
+       --http-address=<%= node["nsq"]["nsqadmin"]["http_address"] %> 2>&1

--- a/templates/default/systemd.nsqadmin.conf.erb
+++ b/templates/default/systemd.nsqadmin.conf.erb
@@ -1,0 +1,18 @@
+[Unit]
+Description=nsqadmin
+After=network.target
+StartLimitIntervalSec=30
+
+[Service]
+User=<%= node['nsq']['nsqadmin']['user'] %>
+Group=<%= node['nsq']['nsqadmin']['user'] %>
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+ExecStart=<%= node['chef-nsq']['script_dir'] %>/nsqadmin-start.sh
+Restart=on-failure
+RestartSec=1
+StartLimitAction=none
+StartLimitBurst=5
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change updates the nsqadmin recipe to work on Ubuntu 18.04 by adding a systemd service file to manage the execution of the nsqadmin process