### PR TITLE
Fix systemd support for nsqadmin

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
+cookbook 'apt', '= 6.1.4'
 cookbook 'ark', '>=2.0.2' # not pinned to this version strongly, it just helps us escape dependency hell
 metadata
-
+cookbook 'seven_zip', '~> 2.0.2'
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -6,7 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: true
+  require_chef_omnibus: '12'
 
 verifier:
   name: inspec
@@ -18,7 +18,13 @@ platforms:
 suites:
   - name: nsqd
     run_list:
+      - recipe[apt]
       - recipe[nsq::nsqd]
   - name: nsqlookupd
     run_list:
+      - recipe[apt]
       - recipe[nsq::nsqlookupd]
+  - name: nsqadmin
+    run_list:
+      - recipe[apt]
+      - recipe[nsq::nsqadmin]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.3'
+version '1.3.4'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/recipes/nsqadmin.rb
+++ b/recipes/nsqadmin.rb
@@ -20,7 +20,7 @@ if node['nsq']['setup_services']
       action :create
       source 'systemd.nsqadmin.conf.erb'
       mode '0644'
-      notifies :run, 'systemd_unit[nsqadmin.service]', :delayed
+      notifies :start, 'systemd_unit[nsqadmin.service]', :delayed
       # need to stop/start in order to reload config
       if node['nsq']['reload_services']
         notifies :stop, 'service[nsqadmin]', :immediately
@@ -52,10 +52,8 @@ if node['nsq']['setup_services']
       end
     end
   end
-
   service 'nsqadmin' do
     action [:enable, :start]
-    supports stop: true, start: true, restart: true, status: true
     if node['nsq']['reload_services']
       subscribes :restart, "ark[#{nsq_release}]", :delayed
     end

--- a/templates/default/nsqadmin-start.sh.erb
+++ b/templates/default/nsqadmin-start.sh.erb
@@ -6,7 +6,7 @@ mkfifo /tmp/nsqadmin-log-fifo
 exec >/tmp/nsqadmin-log-fifo
 rm /tmp/nsqadmin-log-fifo
 
-exec su -s /bin/sh -c 'exec "$0" "$@"' <%= node["nsq"]["nsqadmin"]["user"] %> -- /usr/local/bin/nsqadmin \
+/usr/local/bin/nsqadmin \
        --template-dir <%= node["nsq"]["nsqadmin"]["nsqd_template_dir"] %> \
        <%- node["nsq"]["nsqadmin"]["lookupd_http_address"].each do |lookup_host| %>
            --lookupd-http-address=<%= lookup_host %> \

--- a/test/integration/nsqadmin/default_test.rb
+++ b/test/integration/nsqadmin/default_test.rb
@@ -1,0 +1,9 @@
+describe service('nsqadmin') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe http('http://127.0.0.1:4171/') do
+  its('status') { should cmp 200 }
+end


### PR DESCRIPTION
nsqadmin was failing to start because it was trying to invoke the weird
run-as-user stuff from our upstart world.
Also, add kitchen suite for nsqadmin on ubuntu 14 and 18, and make this
stuff testable on chef 12.